### PR TITLE
BE-8005: Cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,35 @@
+ifeq ($(TRAVIS), true)
+	GO := go
+else
+	GO := go1.18beta2
+endif
+
 .PHONY: lint
 lint:
 	golangci-lint run
 
 .PHONY: test
-test: lint
-	go vet ./...
-	go test --race --cover $$(go list ./...)
+test: # lint
+	${GO} vet ./...
+	${GO} test --race --cover $$(${GO} list ./...)
 
 .PHONY: docs
 docs:
-	go generate $$(go list ./...)
+	${GO} generate $$(${GO} list ./...)
 
 .PHONY: tidy
 tidy:
-	go mod tidy
+	${GO} mod tidy
 
 .PHONY: test-coverage
 test-coverage: lint
-	go vet ./...
+	${GO} vet ./...
 	COVEROUT=$$(mktemp)
-	go test -coverprofile="$COVEROUT" $$(go list ./...)
-	go tool cover -html="$COVEROUT"
+	${GO} test -coverprofile="$COVEROUT" $$(go list ./...)
+	${GO} tool cover -html="$COVEROUT"
 	rm -f "$COVEROUT"
 
 .PHONY: fmt
 fmt:
-	go fmt ./...
+	${GO} fmt ./...
 	find . -name '*.go' -exec gci -w -local github.com/gametimesf/testy {} \; > /dev/null

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ lint:
 	golangci-lint run
 
 .PHONY: test
-test: # lint
+test: # lint # TODO add lint back when golangci-lint supports type parameters
 	${GO} vet ./...
 	${GO} test --race --cover $$(${GO} list ./...)
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,4 @@
-ifeq ($(TRAVIS), true)
-	GO := go
-else
-	GO := go1.18beta2
-endif
+GO := go1.18beta2
 
 .PHONY: lint
 lint:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Go Reference](https://pkg.go.dev/badge/github.com/gametimesf/testy.svg)](https://pkg.go.dev/github.com/gametimesf/testy)
+
 # Testy
 
 Docs incoming :)

--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ Docs incoming :)
 We couldn't find a framework that addressed our API acceptance testing desires, so we're making one ourselves. This
 project is still a rapid work in progress, so full details will be added once things start to stabilize a bit and
 we're actually using this for tests.
+
+This requires go 1.18 (latest beta or rc preferred, if it isn't fully released by the time you read this) due to using type parameters.

--- a/echo.go
+++ b/echo.go
@@ -13,5 +13,6 @@ func AddEchoRoutes(router *echo.Group) {
 
 func runTests(c echo.Context) error {
 	results := Run()
+	// TODO convert results into a better format?
 	return c.JSON(http.StatusOK, results)
 }

--- a/orderedmap/map.go
+++ b/orderedmap/map.go
@@ -6,6 +6,8 @@ import (
 )
 
 // OrderedMap is a map that can be iterated in the natural order of its keys.
+//
+// TODO implement json.Marshaler and json.Unmarshaler
 type OrderedMap[K constraints.Ordered, V any] map[K]V
 
 // Iterate iterates over the keys of the OrderedMap in natural sort order. If the iterator returns false, iteration is

--- a/register.go
+++ b/register.go
@@ -1,0 +1,54 @@
+package testy
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/gametimesf/testy/orderedmap"
+)
+
+var regLock sync.Mutex
+
+// RegisterTest registers a new test to be run. Tests are run in lexicographical order within a package. The return
+// value may be discarded (and is always nil); it is provided to simplify writing test code, like so:
+//
+//    var _ = testy.RegisterTest("my test", func(t testy.TestingT){})
+func RegisterTest(name string, tester Tester) any {
+	// we only care about our immediate caller
+	callers := make([]uintptr, 1)
+	// skip over Callers and ourselves
+	n := runtime.Callers(2, callers[:])
+	pkg := "<unknown>"
+	// make sure it was able to actually get our caller
+	if n > 0 {
+		frames := runtime.CallersFrames(callers)
+		frame, _ := frames.Next()
+		// remove the function name (which is almost certainly "init") and leave just the package name.
+		// as an example, this function is `github.com/gametimesf/testy.RegisterTest`.
+		i := strings.LastIndex(frame.Function, ".")
+		pkg = frame.Function[:i]
+	}
+
+	regLock.Lock()
+	defer regLock.Unlock()
+	if instance.tests == nil {
+		instance.tests = make(orderedmap.OrderedMap[string, orderedmap.OrderedMap[string, testCase]])
+	}
+	if instance.tests[pkg] == nil {
+		instance.tests[pkg] = make(orderedmap.OrderedMap[string, testCase])
+	}
+
+	if _, exists := instance.tests[pkg][name]; exists {
+		panic(fmt.Sprintf("test %s already exists in package %s", name, pkg))
+	}
+
+	instance.tests[pkg][name] = testCase{
+		Package: pkg,
+		Name:    name,
+		tester:  tester,
+	}
+
+	return nil
+}

--- a/register.go
+++ b/register.go
@@ -11,8 +11,10 @@ import (
 
 var regLock sync.Mutex
 
-// RegisterTest registers a new test to be run. Tests are run in lexicographical order within a package. The return
-// value may be discarded (and is always nil); it is provided to simplify writing test code, like so:
+// RegisterTest registers a new test to be run. Tests are run in lexicographical order within a package.
+// TODO: support the -shuffle testflag.
+//
+// The return value may be discarded (and is always nil); it is provided to simplify writing test code, like so:
 //
 //    var _ = testy.RegisterTest("my test", func(t testy.TestingT){})
 func RegisterTest(name string, tester Tester) any {

--- a/run.go
+++ b/run.go
@@ -16,9 +16,7 @@ import (
 func RunAsTest(t *testing.T) {
 	t.Helper()
 	instance.tests.Iterate(func(pkg string, tests orderedmap.OrderedMap[string, testCase]) bool {
-		// for _, tests := range instance.tests {
 		tests.Iterate(func(name string, test testCase) bool {
-			// for _, test := range tests {
 			t.Run(test.Name, func(tt *testing.T) {
 				tt.Helper()
 				test.tester(tWrapper{t: tt})

--- a/run.go
+++ b/run.go
@@ -1,0 +1,111 @@
+package testy
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gametimesf/testy/orderedmap"
+)
+
+// RunAsTest runs all registered tests under Go's testing framework. To run tests on a per-package basis, put a test
+// file in each package containing a single test that calls this function. This is recommended so accurate per-package
+// execution times are reported, as well as using the test cache. Do not import a test package into another test package
+// as that will cause the tests in the second package to get executed with the first package. If code or resources need
+// shared between test packages, put them in their own package which does not contain any test definitions.
+func RunAsTest(t *testing.T) {
+	t.Helper()
+	instance.tests.Iterate(func(pkg string, tests orderedmap.OrderedMap[string, testCase]) bool {
+		// for _, tests := range instance.tests {
+		tests.Iterate(func(name string, test testCase) bool {
+			// for _, test := range tests {
+			t.Run(test.Name, func(tt *testing.T) {
+				tt.Helper()
+				test.tester(tWrapper{t: tt})
+			})
+			return true
+		})
+		return true
+	})
+}
+
+// Run runs all registered tests and returns result information about them.
+//
+// TODO: ability to filter for specific packages and tests
+// TODO: channel for results to support progressive result loading?
+func Run() orderedmap.OrderedMap[string, orderedmap.OrderedMap[string, TestResult]] {
+	results := make(orderedmap.OrderedMap[string, orderedmap.OrderedMap[string, TestResult]])
+
+	instance.tests.Iterate(func(pkg string, tests orderedmap.OrderedMap[string, testCase]) bool {
+		results[pkg] = make(orderedmap.OrderedMap[string, TestResult])
+		tests.Iterate(func(name string, test testCase) bool {
+
+			res := make(chan TestResult)
+
+			wg := sync.WaitGroup{}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for r := range res {
+					results[pkg][r.Name] = r
+				}
+			}()
+
+			runTest(pkg, test.Name, test.tester, res)
+			close(res)
+			wg.Wait()
+
+			return true
+		})
+		return true
+	})
+
+	return results
+}
+
+func runTest(pkg, baseName string, tester Tester, results chan<- TestResult) {
+	subtests := make(chan subtest)
+	subtestDone := make(chan struct{})
+	t := &t{
+		name:        baseName,
+		tester:      tester,
+		subtests:    subtests,
+		subtestDone: subtestDone,
+	}
+
+	stWg := sync.WaitGroup{}
+	stWg.Add(1)
+
+	go func() {
+		defer stWg.Done()
+		for st := range subtests {
+			runTest(pkg, baseName+"/"+st.name, st.tester, results)
+			subtestDone <- struct{}{}
+		}
+	}()
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	start := time.Now()
+	// run in another goroutine so FailNow can work
+	go func() {
+		defer wg.Done()
+		t.run()
+	}()
+	// wait for original test to finish
+	wg.Wait()
+	// this shouldn't be needed since the test actually waits for the subtest to complete before continuing, but it
+	// doesn't hurt to be careful
+	stWg.Wait()
+	close(subtestDone)
+	dur := time.Now().Sub(start)
+
+	results <- TestResult{
+		Package: pkg,
+		Name:    baseName,
+		Msgs:    t.msgs,
+		Passed:  !t.failed,
+		Dur:     dur,
+	}
+}

--- a/t.go
+++ b/t.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 )
 
-type T struct {
+type t struct {
 	name        string
 	tester      Tester
 	failed      bool
@@ -19,9 +19,9 @@ type subtest struct {
 	tester Tester
 }
 
-var _ TestingT = (*T)(nil)
+var _ TestingT = (*t)(nil)
 
-func (t *T) run() {
+func (t *t) run() {
 	defer func() {
 		// catch panics and mark test as failed
 		if err := recover(); err != nil {
@@ -35,47 +35,47 @@ func (t *T) run() {
 	t.tester(t)
 }
 
-func (t *T) Fail() {
+func (t *t) Fail() {
 	t.failed = true
 }
 
-func (t *T) FailNow() {
+func (t *t) FailNow() {
 	t.failed = true
 	runtime.Goexit()
 }
 
-func (t *T) Fatal(args ...interface{}) {
+func (t *t) Fatal(args ...interface{}) {
 	t.msgs = append(t.msgs, Msg{Msg: fmt.Sprintln(args...), Level: LevelError})
 	t.FailNow()
 }
 
-func (t *T) Fatalf(format string, args ...interface{}) {
+func (t *t) Fatalf(format string, args ...interface{}) {
 	t.msgs = append(t.msgs, Msg{Msg: fmt.Sprintf(format, args...), Level: LevelError})
 	t.FailNow()
 }
 
-func (t *T) Errorf(format string, args ...interface{}) {
+func (t *t) Errorf(format string, args ...interface{}) {
 	t.msgs = append(t.msgs, Msg{Msg: fmt.Sprintf(format, args...), Level: LevelError})
 	t.failed = true
 }
 
-func (t *T) Helper() {
+func (t *t) Helper() {
 	// nothing to do here, I think?
 }
 
-func (t *T) Log(args ...interface{}) {
+func (t *t) Log(args ...interface{}) {
 	t.msgs = append(t.msgs, Msg{Msg: fmt.Sprintln(args...), Level: LevelInfo})
 }
 
-func (t *T) Logf(format string, args ...interface{}) {
+func (t *t) Logf(format string, args ...interface{}) {
 	t.msgs = append(t.msgs, Msg{Msg: fmt.Sprintf(format, args...), Level: LevelInfo})
 }
 
-func (t *T) Name() string {
+func (t *t) Name() string {
 	return t.name
 }
 
-func (t *T) Run(name string, tester Tester) {
+func (t *t) Run(name string, tester Tester) {
 	t.subtests <- subtest{
 		name:   name,
 		tester: tester,

--- a/t.go
+++ b/t.go
@@ -6,13 +6,33 @@ import (
 )
 
 type T struct {
+	name     string
+	tester   Tester
+	failed   bool
+	msgs     []Msg
+	subtests chan<- subtest
+}
+
+type subtest struct {
 	name   string
-	failed bool
-	// TODO differentiate logs from errors
-	msgs []string
+	tester Tester
 }
 
 var _ TestingT = (*T)(nil)
+
+func (t *T) run() {
+	defer func() {
+		// catch panics and mark test as failed
+		if err := recover(); err != nil {
+			// not using Fatalf since we're already in the defer that would get run and we need to clean up the channel
+			t.Errorf("panic: %+v", err)
+			t.Fail()
+		}
+		close(t.subtests)
+	}()
+
+	t.tester(t)
+}
 
 func (t *T) Fail() {
 	t.failed = true
@@ -24,17 +44,17 @@ func (t *T) FailNow() {
 }
 
 func (t *T) Fatal(args ...interface{}) {
-	t.msgs = append(t.msgs, fmt.Sprintln(args...))
+	t.msgs = append(t.msgs, Msg{Msg: fmt.Sprintln(args...), Level: LevelError})
 	t.FailNow()
 }
 
 func (t *T) Fatalf(format string, args ...interface{}) {
-	t.msgs = append(t.msgs, fmt.Sprintf(format, args...))
+	t.msgs = append(t.msgs, Msg{Msg: fmt.Sprintf(format, args...), Level: LevelError})
 	t.FailNow()
 }
 
 func (t *T) Errorf(format string, args ...interface{}) {
-	t.msgs = append(t.msgs, fmt.Sprintf(format, args...))
+	t.msgs = append(t.msgs, Msg{Msg: fmt.Sprintf(format, args...), Level: LevelError})
 	t.failed = true
 }
 
@@ -43,13 +63,20 @@ func (t *T) Helper() {
 }
 
 func (t *T) Log(args ...interface{}) {
-	t.msgs = append(t.msgs, fmt.Sprintln(args...))
+	t.msgs = append(t.msgs, Msg{Msg: fmt.Sprintln(args...), Level: LevelInfo})
 }
 
 func (t *T) Logf(format string, args ...interface{}) {
-	t.msgs = append(t.msgs, fmt.Sprintf(format, args...))
+	t.msgs = append(t.msgs, Msg{Msg: fmt.Sprintf(format, args...), Level: LevelInfo})
 }
 
 func (t *T) Name() string {
 	return t.name
+}
+
+func (t *T) Run(name string, tester Tester) {
+	t.subtests <- subtest{
+		name:   name,
+		tester: tester,
+	}
 }

--- a/t.go
+++ b/t.go
@@ -6,11 +6,12 @@ import (
 )
 
 type T struct {
-	name     string
-	tester   Tester
-	failed   bool
-	msgs     []Msg
-	subtests chan<- subtest
+	name        string
+	tester      Tester
+	failed      bool
+	msgs        []Msg
+	subtests    chan<- subtest
+	subtestDone <-chan struct{}
 }
 
 type subtest struct {
@@ -79,4 +80,5 @@ func (t *T) Run(name string, tester Tester) {
 		name:   name,
 		tester: tester,
 	}
+	<-t.subtestDone
 }

--- a/testy.go
+++ b/testy.go
@@ -188,7 +188,8 @@ func runTest(pkg, baseName string, tester Tester, results chan<- TestResult) {
 	}()
 	// wait for original test to finish
 	wg.Wait()
-	close(subtests)
+	// this shouldn't be needed since the test actually waits for the subtest to complete before continuing, but it
+	// doesn't hurt to be careful
 	stWg.Wait()
 	close(subtestDone)
 	dur := time.Now().Sub(start)

--- a/testy.go
+++ b/testy.go
@@ -1,11 +1,6 @@
 package testy
 
 import (
-	"fmt"
-	"runtime"
-	"strings"
-	"sync"
-	"testing"
 	"time"
 
 	"github.com/gametimesf/testy/orderedmap"
@@ -13,6 +8,34 @@ import (
 
 type testy struct {
 	tests orderedmap.OrderedMap[string, orderedmap.OrderedMap[string, testCase]]
+}
+
+type testCase struct {
+	Package string
+	Name    string
+	tester  Tester
+}
+
+type Tester func(t TestingT)
+
+type TestResult struct {
+	Package string
+	Name    string
+	Msgs    []Msg
+	Passed  bool
+	Dur     time.Duration
+}
+
+type Level string
+
+const (
+	LevelInfo  Level = "info"
+	LevelError Level = "error"
+)
+
+type Msg struct {
+	Msg   string
+	Level Level
 }
 
 var instance testy
@@ -31,176 +54,4 @@ type TestingT interface {
 	Logf(format string, args ...interface{})
 	Name() string
 	Run(string, Tester)
-}
-
-type Tester func(t TestingT)
-
-type testCase struct {
-	Package string
-	Name    string
-	tester  Tester
-}
-
-type Level string
-
-const (
-	LevelInfo  Level = "info"
-	LevelError Level = "error"
-)
-
-type Msg struct {
-	Msg   string
-	Level Level
-}
-
-type TestResult struct {
-	Package string
-	Name    string
-	Msgs    []Msg
-	Passed  bool
-	Dur     time.Duration
-}
-
-var regLock sync.Mutex
-
-func RegisterTest(name string, tester Tester) any {
-	// we only care about our immediate caller
-	callers := make([]uintptr, 1)
-	// skip over Callers and ourselves
-	n := runtime.Callers(2, callers[:])
-	pkg := "<unknown>"
-	// make sure it was able to actually get our caller
-	if n > 0 {
-		frames := runtime.CallersFrames(callers)
-		frame, _ := frames.Next()
-		// remove the function name (which is almost certainly "init") and leave just the package name.
-		// as an example, this function is `github.com/gametimesf/testy.RegisterTest`.
-		i := strings.LastIndex(frame.Function, ".")
-		pkg = frame.Function[:i]
-	}
-
-	regLock.Lock()
-	defer regLock.Unlock()
-	if instance.tests == nil {
-		instance.tests = make(orderedmap.OrderedMap[string, orderedmap.OrderedMap[string, testCase]])
-	}
-	if instance.tests[pkg] == nil {
-		instance.tests[pkg] = make(orderedmap.OrderedMap[string, testCase])
-	}
-
-	if _, exists := instance.tests[pkg][name]; exists {
-		panic(fmt.Sprintf("test %s already exists in package %s", name, pkg))
-	}
-
-	instance.tests[pkg][name] = testCase{
-		Package: pkg,
-		Name:    name,
-		tester:  tester,
-	}
-
-	return nil
-}
-
-// RunAsTest runs all registered tests under Go's testing framework. To run tests on a per-package basis, put a test
-// file in each package containing a single test that calls this function. This is recommended so accurate per-package
-// execution times are reported, as well as using the test cache. Do not import a test package into another test package
-// as that will cause the tests in the second package to get executed with the first package. If code or resources need
-// shared between test packages, put them in their own package which does not contain any test definitions.
-func RunAsTest(t *testing.T) {
-	t.Helper()
-	instance.tests.Iterate(func(pkg string, tests orderedmap.OrderedMap[string, testCase]) bool {
-		// for _, tests := range instance.tests {
-		tests.Iterate(func(name string, test testCase) bool {
-			// for _, test := range tests {
-			t.Run(test.Name, func(tt *testing.T) {
-				tt.Helper()
-				test.tester(tWrapper{t: tt})
-			})
-			return true
-		})
-		return true
-	})
-}
-
-// Run runs all registered tests and returns result information about them.
-//
-// TODO: ability to filter for specific packages and tests
-// TODO: channel for results to support progressive result loading?
-func Run() orderedmap.OrderedMap[string, orderedmap.OrderedMap[string, TestResult]] {
-	results := make(orderedmap.OrderedMap[string, orderedmap.OrderedMap[string, TestResult]])
-
-	instance.tests.Iterate(func(pkg string, tests orderedmap.OrderedMap[string, testCase]) bool {
-		results[pkg] = make(orderedmap.OrderedMap[string, TestResult])
-		tests.Iterate(func(name string, test testCase) bool {
-
-			res := make(chan TestResult)
-
-			wg := sync.WaitGroup{}
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				for r := range res {
-					results[pkg][r.Name] = r
-				}
-			}()
-
-			runTest(pkg, test.Name, test.tester, res)
-			close(res)
-			wg.Wait()
-
-			return true
-		})
-		return true
-	})
-
-	return results
-}
-
-func runTest(pkg, baseName string, tester Tester, results chan<- TestResult) {
-	subtests := make(chan subtest)
-	subtestDone := make(chan struct{})
-	t := &T{
-		name:        baseName,
-		tester:      tester,
-		subtests:    subtests,
-		subtestDone: subtestDone,
-	}
-
-	stWg := sync.WaitGroup{}
-	stWg.Add(1)
-
-	go func() {
-		defer stWg.Done()
-		for st := range subtests {
-			runTest(pkg, baseName+"/"+st.name, st.tester, results)
-			subtestDone <- struct{}{}
-		}
-	}()
-
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-
-	start := time.Now()
-	// run in another goroutine so FailNow can work
-	go func() {
-		defer wg.Done()
-		t.run()
-	}()
-	// wait for original test to finish
-	wg.Wait()
-	// this shouldn't be needed since the test actually waits for the subtest to complete before continuing, but it
-	// doesn't hurt to be careful
-	stWg.Wait()
-	close(subtestDone)
-	dur := time.Now().Sub(start)
-
-	// TODO handle t.Run calls and recurse
-
-	results <- TestResult{
-		Package: pkg,
-		Name:    baseName,
-		Msgs:    t.msgs,
-		Passed:  !t.failed,
-		Dur:     dur,
-	}
 }

--- a/twrapper.go
+++ b/twrapper.go
@@ -1,0 +1,54 @@
+package testy
+
+import (
+	"testing"
+)
+
+// tWrapper wraps a real testing.T, because Run takes a concrete implementation.
+type tWrapper struct {
+	t *testing.T
+}
+
+var _ TestingT = (*tWrapper)(nil)
+
+func (t tWrapper) Fail() {
+	t.t.Fail()
+}
+
+func (t tWrapper) FailNow() {
+	t.t.FailNow()
+}
+
+func (t tWrapper) Fatal(args ...interface{}) {
+	t.t.Fatal(args...)
+}
+
+func (t tWrapper) Fatalf(format string, args ...interface{}) {
+	t.t.Fatalf(format, args...)
+}
+
+func (t tWrapper) Errorf(format string, args ...interface{}) {
+	t.t.Errorf(format, args...)
+}
+
+func (t tWrapper) Helper() {
+	t.t.Helper()
+}
+
+func (t tWrapper) Log(args ...interface{}) {
+	t.t.Log(args...)
+}
+
+func (t tWrapper) Logf(format string, args ...interface{}) {
+	t.t.Logf(format, args...)
+}
+
+func (t tWrapper) Name() string {
+	return t.t.Name()
+}
+
+func (t tWrapper) Run(s string, tester Tester) {
+	t.t.Run(s, func(tt *testing.T) {
+		tester(tWrapper{t: tt})
+	})
+}


### PR DESCRIPTION
* decouple test cases from test results
* differentiate errors from logs
* use correct iteration order for tests
* refactor for supporting t.Run
* split stuff into multiple files

This is not going to be the only PR for this ticket; I am doing things in stages.