### PR TITLE
BE-8029: return Run success

### DIFF
--- a/run.go
+++ b/run.go
@@ -267,7 +267,7 @@ func runTest(pkg, baseName string, tester Tester) TestResult {
 	}
 
 	subtests := make(chan subtest)
-	subtestDone := make(chan struct{})
+	subtestDone := make(chan bool)
 	t := &t{
 		name:        baseName,
 		tester:      tester,
@@ -288,7 +288,7 @@ func runTest(pkg, baseName string, tester Tester) TestResult {
 				anyFailures = true
 			}
 			result.Subtests = append(result.Subtests, stResult)
-			subtestDone <- struct{}{}
+			subtestDone <- stResult.Result == ResultPassed
 		}
 	}()
 

--- a/run.go
+++ b/run.go
@@ -288,7 +288,7 @@ func runTest(pkg, baseName string, tester Tester) TestResult {
 				anyFailures = true
 			}
 			result.Subtests = append(result.Subtests, stResult)
-			subtestDone <- stResult.Result == ResultPassed
+			subtestDone <- stResult.Result != ResultFailed
 		}
 	}()
 

--- a/run_test.go
+++ b/run_test.go
@@ -10,6 +10,7 @@ import (
 
 // know that before/after package/test and the test itself have run and when they were run
 var bp, bt, at, ap, tt time.Time
+var subtestResult *bool
 
 func succeeds(ts *time.Time) Tester {
 	return func(TestingT) {
@@ -32,7 +33,8 @@ func fails(ts *time.Time) Tester {
 
 func subtestForTest(tester Tester) Tester {
 	return func(t TestingT) {
-		t.Run("subtest", tester)
+		b := t.Run("subtest", tester)
+		subtestResult = &b
 	}
 }
 
@@ -65,6 +67,8 @@ var runTCs = []runTC{
 
 			assert.Equal(t, ResultPassed, tr.Result)
 			assert.Len(t, tr.Msgs, 0)
+
+			assert.Nil(t, subtestResult)
 		},
 	},
 	{
@@ -87,6 +91,9 @@ var runTCs = []runTC{
 			require.Len(t, tr.Subtests, 1)
 			assert.Equal(t, ResultPassed, tr.Subtests[0].Result)
 			assert.Len(t, tr.Subtests[0].Msgs, 0)
+
+			require.NotNil(t, subtestResult)
+			assert.True(t, *subtestResult)
 		},
 	},
 	{
@@ -106,6 +113,8 @@ var runTCs = []runTC{
 
 			assert.Equal(t, ResultFailed, tr.Result)
 			assert.Len(t, tr.Msgs, 1)
+
+			assert.Nil(t, subtestResult)
 		},
 	},
 	{
@@ -128,6 +137,9 @@ var runTCs = []runTC{
 			require.Len(t, tr.Subtests, 1)
 			assert.Equal(t, ResultFailed, tr.Subtests[0].Result)
 			assert.Len(t, tr.Subtests[0].Msgs, 1)
+
+			require.NotNil(t, subtestResult)
+			assert.False(t, *subtestResult)
 		},
 	},
 	{
@@ -147,6 +159,8 @@ var runTCs = []runTC{
 
 			assert.Equal(t, ResultFailed, tr.Result)
 			assert.Len(t, tr.Msgs, 1)
+
+			assert.Nil(t, subtestResult)
 		},
 	},
 	{
@@ -169,6 +183,9 @@ var runTCs = []runTC{
 			require.Len(t, tr.Subtests, 1)
 			assert.Equal(t, ResultFailed, tr.Subtests[0].Result)
 			assert.Len(t, tr.Subtests[0].Msgs, 1)
+
+			require.NotNil(t, subtestResult)
+			assert.False(t, *subtestResult)
 		},
 	},
 	{
@@ -188,6 +205,8 @@ var runTCs = []runTC{
 
 			assert.Equal(t, ResultPassed, tr.Result)
 			assert.Len(t, tr.Msgs, 0)
+
+			assert.Nil(t, subtestResult)
 		},
 	},
 	{
@@ -207,6 +226,8 @@ var runTCs = []runTC{
 
 			assert.Equal(t, ResultFailed, tr.Result)
 			assert.Len(t, tr.Msgs, 1)
+
+			assert.Nil(t, subtestResult)
 		},
 	},
 	{
@@ -226,6 +247,8 @@ var runTCs = []runTC{
 
 			assert.Equal(t, ResultFailed, tr.Result)
 			assert.Len(t, tr.Msgs, 1)
+
+			assert.Nil(t, subtestResult)
 		},
 	},
 	{
@@ -245,6 +268,8 @@ var runTCs = []runTC{
 
 			assert.Equal(t, ResultPassed, tr.Result)
 			assert.Len(t, tr.Msgs, 0)
+
+			assert.Nil(t, subtestResult)
 		},
 	},
 	{
@@ -264,6 +289,8 @@ var runTCs = []runTC{
 
 			assert.Equal(t, ResultPassed, tr.Result)
 			assert.Len(t, tr.Msgs, 0)
+
+			assert.Nil(t, subtestResult)
 		},
 	},
 	{
@@ -283,6 +310,8 @@ var runTCs = []runTC{
 
 			assert.Equal(t, ResultPassed, tr.Result)
 			assert.Len(t, tr.Msgs, 0)
+
+			assert.Nil(t, subtestResult)
 		},
 	},
 	{
@@ -302,6 +331,8 @@ var runTCs = []runTC{
 
 			assert.Equal(t, ResultPassed, tr.Result)
 			assert.Len(t, tr.Msgs, 0)
+
+			assert.Nil(t, subtestResult)
 		},
 	},
 	{
@@ -321,6 +352,8 @@ var runTCs = []runTC{
 
 			assert.Equal(t, ResultFailed, tr.Result)
 			assert.Len(t, tr.Msgs, 1)
+
+			assert.Nil(t, subtestResult)
 		},
 	},
 	{
@@ -340,6 +373,8 @@ var runTCs = []runTC{
 
 			assert.Equal(t, ResultFailed, tr.Result)
 			assert.Len(t, tr.Msgs, 2)
+
+			assert.Nil(t, subtestResult)
 		},
 	},
 	{
@@ -359,6 +394,8 @@ var runTCs = []runTC{
 
 			assert.Equal(t, ResultFailed, tr.Result)
 			assert.Len(t, tr.Msgs, 1)
+
+			assert.Nil(t, subtestResult)
 		},
 	},
 }
@@ -373,6 +410,7 @@ func TestRun(t *testing.T) {
 			at = time.Time{}
 			ap = time.Time{}
 			tt = time.Time{}
+			subtestResult = nil
 
 			// set up everything we need
 

--- a/t.go
+++ b/t.go
@@ -12,7 +12,7 @@ type t struct {
 	failed      bool
 	msgs        []Msg
 	subtests    chan<- subtest
-	subtestDone <-chan struct{}
+	subtestDone <-chan bool
 }
 
 type subtest struct {
@@ -85,7 +85,7 @@ func (t *t) Name() string {
 	return t.name
 }
 
-func (t *t) Run(name string, tester Tester) {
+func (t *t) Run(name string, tester Tester) bool {
 	if !t.test() {
 		panic("attempting to run subtest on non-subtest-capable T (you can only Run in Tests, not Before/After)")
 	}
@@ -93,5 +93,5 @@ func (t *t) Run(name string, tester Tester) {
 		name:   strings.Map(stripName, name),
 		tester: tester,
 	}
-	<-t.subtestDone
+	return <-t.subtestDone
 }

--- a/testy.go
+++ b/testy.go
@@ -71,7 +71,7 @@ type TestingT interface {
 	Log(args ...interface{})
 	Logf(format string, args ...interface{})
 	Name() string
-	Run(string, Tester)
+	Run(string, Tester) bool
 }
 
 func stripName(r rune) rune {

--- a/twrapper.go
+++ b/twrapper.go
@@ -47,8 +47,10 @@ func (t tWrapper) Name() string {
 	return t.t.Name()
 }
 
-func (t tWrapper) Run(s string, tester Tester) {
-	t.t.Run(s, func(tt *testing.T) {
+func (t tWrapper) Run(s string, tester Tester) bool {
+	t.t.Helper()
+	return t.t.Run(s, func(tt *testing.T) {
+		t.t.Helper()
 		tester(tWrapper{t: tt})
 	})
 }

--- a/twrapper.go
+++ b/twrapper.go
@@ -12,34 +12,42 @@ type tWrapper struct {
 var _ TestingT = (*tWrapper)(nil)
 
 func (t tWrapper) Fail() {
+	t.Helper()
 	t.t.Fail()
 }
 
 func (t tWrapper) FailNow() {
+	t.Helper()
 	t.t.FailNow()
 }
 
 func (t tWrapper) Fatal(args ...interface{}) {
+	t.Helper()
 	t.t.Fatal(args...)
 }
 
 func (t tWrapper) Fatalf(format string, args ...interface{}) {
+	t.Helper()
 	t.t.Fatalf(format, args...)
 }
 
 func (t tWrapper) Errorf(format string, args ...interface{}) {
+	t.Helper()
 	t.t.Errorf(format, args...)
 }
 
 func (t tWrapper) Helper() {
+	// this probably doesn't actually work right since the call stack is incorrect
 	t.t.Helper()
 }
 
 func (t tWrapper) Log(args ...interface{}) {
+	t.Helper()
 	t.t.Log(args...)
 }
 
 func (t tWrapper) Logf(format string, args ...interface{}) {
+	t.Helper()
 	t.t.Logf(format, args...)
 }
 


### PR DESCRIPTION
make Run return what testing.T.Run returns, so a test can directly examine if its subtests succeeded without needing to keep track of that itself