### PR TITLE
BE-8067: Ability to save test results

### DIFF
--- a/db.go
+++ b/db.go
@@ -1,0 +1,30 @@
+package testy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+var ErrNoDB = errors.New("no DB set")
+
+// DB is the interface for something which can save and retrieve test reports.
+type DB interface {
+	// Save stores the provided TestResult in the data store and returns its unique ID.
+	Save(context.Context, TestResult) (string, error)
+}
+
+// SetDB sets the datastore to use for test reports.
+func SetDB(db DB) {
+	instance.db = db
+}
+
+// SaveResult saves the provided result to the registered datastore. If no datastore has been registered, an error
+// wrapping ErrNoDB is returned.
+func SaveResult(ctx context.Context, tr TestResult) (string, error) {
+	if instance.db == nil {
+		return "", fmt.Errorf("%w", ErrNoDB)
+	}
+
+	return instance.db.Save(ctx, tr)
+}

--- a/echo.go
+++ b/echo.go
@@ -13,6 +13,13 @@ func AddEchoRoutes(router *echo.Group) {
 
 func runTests(c echo.Context) error {
 	results := Run()
+
+	if instance.db != nil {
+		// TODO do we want to alert this somehow?
+		// doesn't make sense to return an http error since we do have test results
+		_, _ = SaveResult(c.Request().Context(), results)
+	}
+
 	// TODO convert results into a better format?
 	return c.JSON(http.StatusOK, results)
 }

--- a/run.go
+++ b/run.go
@@ -86,10 +86,11 @@ func RunAsTest(t *testing.T) {
 // TODO: shuffle test execution order (see -shuffle in `go help testflag`)
 // TODO: channel for results to support progressive result loading?
 func Run() TestResult {
-	results := TestResult{
-		Name: "Test Suite",
-	}
 	start := time.Now()
+	results := TestResult{
+		Name:    "Test Suite",
+		Started: start,
+	}
 	anyFailures := false
 
 	// TODO run packages in parallel like go test does
@@ -98,6 +99,7 @@ func Run() TestResult {
 		results.Subtests = append(results.Subtests, TestResult{
 			Package: pkg,
 			Name:    "Package",
+			Started: pkgStart,
 		})
 		pkgResults := &results.Subtests[len(results.Subtests)-1]
 
@@ -158,6 +160,7 @@ func Run() TestResult {
 					pkgResults.Subtests = append(pkgResults.Subtests, TestResult{
 						Package:  pkg,
 						Name:     name,
+						Started:  time.Now(),
 						Result:   ResultFailed,
 						Dur:      0,
 						DurHuman: "0s",
@@ -196,6 +199,7 @@ func Run() TestResult {
 				pkgResults.Subtests = append(pkgResults.Subtests, TestResult{
 					Package:  pkg,
 					Name:     name,
+					Started:  pkgStart,
 					Result:   ResultFailed,
 					Dur:      0,
 					DurHuman: "0s",
@@ -315,6 +319,7 @@ func runTest(pkg, baseName string, tester Tester) TestResult {
 	}
 	result.Msgs = t.msgs
 	result.Result = r
+	result.Started = start
 	result.Dur = dur
 	result.DurHuman = dur.String()
 	return result

--- a/testy.go
+++ b/testy.go
@@ -33,6 +33,7 @@ type TestResult struct {
 	Name     string
 	Msgs     []Msg
 	Result   Result
+	Started  time.Time
 	Dur      time.Duration
 	DurHuman string
 	Subtests []TestResult

--- a/testy.go
+++ b/testy.go
@@ -8,6 +8,7 @@ import (
 
 type testy struct {
 	tests orderedmap.OrderedMap[string, *testPkg]
+	db    DB
 }
 
 type testPkg struct {


### PR DESCRIPTION
Add an interface to save test results somewhere. This interface will be expanded shortly to enumerate and retrieve test results.