### PR TITLE
Reflow docs

### DIFF
--- a/db.go
+++ b/db.go
@@ -41,8 +41,8 @@ func SetDB(db DB) {
 	instance.db = db
 }
 
-// SaveResult saves the provided result to the registered datastore. If no datastore has been registered, an error
-// wrapping ErrNoDB is returned.
+// SaveResult saves the provided result to the registered datastore.
+// If no datastore has been registered, an error wrapping ErrNoDB is returned.
 func SaveResult(ctx context.Context, tr TestResult) (string, error) {
 	if instance.db == nil {
 		return "", fmt.Errorf("%w", ErrNoDB)
@@ -51,8 +51,9 @@ func SaveResult(ctx context.Context, tr TestResult) (string, error) {
 	return instance.db.Save(ctx, tr)
 }
 
-// LoadResult loads the specified result from the registered datastore. If no datastore has been registered, an error
-// wrapping ErrNoDB is returned. If the ID is invalid, an error wrapping ErrNotFound is returned.
+// LoadResult loads the specified result from the registered datastore.
+// If no datastore has been registered, an error wrapping ErrNoDB is returned.
+// If the ID is invalid, an error wrapping ErrNotFound is returned.
 func LoadResult(ctx context.Context, id string) (TestResult, error) {
 	if instance.db == nil {
 		return TestResult{}, fmt.Errorf("%w", ErrNoDB)

--- a/helper.go
+++ b/helper.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 )
 
-// TestEach runs tester as a subtest for each value in values. The values should have a good default string
-// representation so the subtest names are legible. (Consider implementing fmt.Stringer for complex structs.)
+// TestEach runs tester as a subtest for each value in values.
+// The values should have a good default string representation so the subtest names are legible.
+// Consider implementing fmt.Stringer for complex structs.
 func TestEach[V any](t TestingT, values []V, tester func(TestingT, V)) {
 	for _, v := range values {
 		t.Run(fmt.Sprintf("%v", v), func(t TestingT) {

--- a/internal/orderedmap/map.go
+++ b/internal/orderedmap/map.go
@@ -10,8 +10,8 @@ import (
 // TODO implement json.Marshaler and json.Unmarshaler?
 type OrderedMap[K cmp.Ordered, V any] map[K]V
 
-// Iterate iterates over the keys of the OrderedMap in natural sort order. If the iterator returns false, iteration is
-// aborted (like the break keyword).
+// Iterate iterates over the keys of the OrderedMap in natural sort order.
+// If the iterator returns false, iteration is aborted (like the break keyword).
 //
 // Iterate is not safe for concurrent modification.
 func (m OrderedMap[K, V]) Iterate(iterator func(key K, value V) bool) {

--- a/register.go
+++ b/register.go
@@ -8,6 +8,166 @@ import (
 	"github.com/gametimesf/testy/internal/orderedmap"
 )
 
+// It is assumed that all funcs in this file are called during package initialization,
+// and as such there is a language guarantee that only one such func will be running at a time,
+// so we don't need to synchronize access to the maps containing packages or tests.
+//
+// For more details, see https://go.dev/ref/spec#Package_initialization
+
+// Test registers a new test to be run.
+// Tests are run in lexicographical order within a package.
+//
+// The return value may be discarded (and is always nil); it is provided to simplify writing test code, like so:
+//
+//	var _ = testy.Test("my test", func(t testy.TestingT){})
+func Test(name string, tester Tester) any {
+	if tester == nil {
+		panic(fmt.Sprintf("test %s has nil test function", name))
+	}
+
+	name = strings.Map(stripName, name)
+	pkg := getCallerPackage()
+	pkgTests := getPackageTests(pkg)
+
+	if _, exists := pkgTests.tests[name]; exists {
+		panic(fmt.Sprintf("test %s already exists in package %s", name, pkg))
+	}
+
+	pkgTests.tests[name] = testCase{
+		Package: pkg,
+		Name:    name,
+		tester:  tester,
+	}
+
+	return nil
+}
+
+// BeforePackage registers a function to be run once before any tests in the given package are run.
+// A package may only have one BeforePackage function.
+//
+// If BeforePackage panics, no tests in the package will be run and the reporting behavior depends on if RunAsTest or Run was called.
+// AfterPackage will still be run.
+//
+// If RunAsTest was called, the panic will be reported as the top-level bootstrap test for the package.
+// If Run was called, every registered test in the package will be marked as failed with the panic's message.
+//
+// When run via Run, any logging output to the provided Tester will only be visible if BeforePackage panics or the Tester is marked as failed.
+// When run via RunAsTest, the standard `go test` output rules apply.
+// Notably, if a test fails, the output is not visible via Run but is via RunAsTest.
+//
+// NOTE: Do not call TestingT.Fail, TestingT.FailNow, TestingT.Fatal, or TestingT.Fatalf in BeforePackage to report errors; always panic.
+// It will work as expected in RunAsTest mode, but not Run mode.
+// TODO parity here.
+//
+// The return value may be discarded (and is always nil); it is provided to simplify writing test code, like so:
+//
+//	var _ = testy.BeforePackage(func(){})
+func BeforePackage(f Tester) any {
+	pkg := getCallerPackage()
+	pkgTests := getPackageTests(pkg)
+
+	if pkgTests.BeforePackage != nil {
+		panic(fmt.Sprintf("package %s already has a BeforePackage", pkg))
+	}
+
+	pkgTests.BeforePackage = f
+	return nil
+}
+
+// AfterPackage registers a function to be run once after all tests in the given package have finished.
+// A package may only have one AfterPackage function.
+//
+// If AfterPackage panics, the reporting behavior depends on if RunAsTest or Run was called.
+// If AfterPackage panics and BeforePackage had already panicked, then the panic for BeforePackage takes priority.
+//
+// If RunAsTest was called, the panic will be reported as the top-level bootstrap test for the package.
+// If Run was called, every test in the package will be marked as failed,
+// and the panic's message will be appended to every test's own messages or the BeforePackage panic that replaced every test.
+//
+// When run via Run, any logging output to the provided Tester will only be visible if AfterPackage panics or the Tester is marked as failed.
+// When run via RunAsTest, the standard `go test` output rules apply.
+// Notably, if a test fails, the output is not visible via Run but is via RunAsTest.
+//
+// NOTE: Do not call TestingT.Fail, TestingT.FailNow, TestingT.Fatal, or TestingT.Fatalf in AfterPackage to report errors; always panic.
+// It will work as expected in RunAsTest mode, but not Run mode.
+// TODO parity here.
+//
+// The return value may be discarded (and is always nil); it is provided to simplify writing test code, like so:
+//
+//	var _ = testy.AfterPackage(func(){})
+func AfterPackage(f Tester) any {
+	pkg := getCallerPackage()
+	pkgTests := getPackageTests(pkg)
+
+	if pkgTests.AfterPackage != nil {
+		panic(fmt.Sprintf("package %s already has an AfterPackage", pkg))
+	}
+
+	pkgTests.AfterPackage = f
+	return nil
+}
+
+// BeforeTest registers a function to be run before every top level registered test in the given package is run.
+// It is not run before subtests created by `t.Run`.
+// A package may only have one BeforeTest function.
+//
+// If BeforeTest panics, the specific registered test that was about to be invoked will be marked as failed with the panic's message.
+// AfterTest will still be run.
+//
+// When run via Run, any logging output to the provided Tester will only be visible if BeforeTest panics or the Tester is marked as failed.
+// When run via RunAsTest, the standard `go test` output rules apply.
+// Notably, if a test fails, the output is not visible via Run but is via RunAsTest.
+//
+// NOTE: Do not call TestingT.Fail, TestingT.FailNow, TestingT.Fatal, or TestingT.Fatalf in BeforeTest to report errors; always panic.
+// It will work as expected in RunAsTest mode, but not Run mode.
+// TODO parity here.
+//
+// The return value may be discarded (and is always nil); it is provided to simplify writing test code, like so:
+//
+//	var _ = testy.BeforeTest(func(){})
+func BeforeTest(f Tester) any {
+	pkg := getCallerPackage()
+	pkgTests := getPackageTests(pkg)
+
+	if pkgTests.BeforeTest != nil {
+		panic(fmt.Sprintf("package %s already has a BeforeTest", pkg))
+	}
+
+	pkgTests.BeforeTest = f
+	return nil
+}
+
+// AfterTest registers a function to be run once after every top level registered test in the given package has finished.
+// It is not run after subtests created by `t.Run`.
+// A package may only have one AfterTest function.
+//
+// If AfterTest panics, the specific test that was just run will be marked as failed,
+// and the panic's message will be appended to the test's own messages.
+// Any subtests of the test will not be modified.
+//
+// When run via Run, any logging output to the provided Tester will only be visible if AfterTest panics or the Tester is marked as failed.
+// When run via RunAsTest, the standard `go test` output rules apply.
+// Notably, if a test fails, the output is not visible via Run but is via RunAsTest.
+//
+// NOTE: Do not call TestingT.Fail, TestingT.FailNow, TestingT.Fatal, or TestingT.Fatalf in AfterTest to report errors; always panic.
+// It will work as expected in RunAsTest mode, but not Run mode.
+// TODO parity here.
+//
+// The return value may be discarded (and is always nil); it is provided to simplify writing test code, like so:
+//
+//	var _ = testy.AfterTest(func(){})
+func AfterTest(f Tester) any {
+	pkg := getCallerPackage()
+	pkgTests := getPackageTests(pkg)
+
+	if pkgTests.AfterTest != nil {
+		panic(fmt.Sprintf("package %s already has an AfterTest", pkg))
+	}
+
+	pkgTests.AfterTest = f
+	return nil
+}
+
 func getCallerPackage() string {
 	// we only care about our immediate caller's immediate caller
 	callers := make([]uintptr, 1)
@@ -47,157 +207,4 @@ func getPackageTests(pkg string) *testPkg {
 	}
 
 	return instance.tests[pkg]
-}
-
-// It is assumed that all funcs in this file are called during package initialization and as such there is a language
-// guarantee that only one such func will be running at a time, so we don't need to synchronize access to the maps
-// containing packages or tests.
-//
-// For more details, see https://go.dev/ref/spec#Package_initialization
-
-// Test registers a new test to be run. Tests are run in lexicographical order within a package.
-// TODO: support the -shuffle testflag. though maybe that only has to be in the runner?
-//
-// The return value may be discarded (and is always nil); it is provided to simplify writing test code, like so:
-//
-//	var _ = testy.Test("my test", func(t testy.TestingT){})
-func Test(name string, tester Tester) any {
-	if tester == nil {
-		panic(fmt.Sprintf("test %s has nil test function", name))
-	}
-
-	name = strings.Map(stripName, name)
-	pkg := getCallerPackage()
-	pkgTests := getPackageTests(pkg)
-
-	if _, exists := pkgTests.tests[name]; exists {
-		panic(fmt.Sprintf("test %s already exists in package %s", name, pkg))
-	}
-
-	pkgTests.tests[name] = testCase{
-		Package: pkg,
-		Name:    name,
-		tester:  tester,
-	}
-
-	return nil
-}
-
-// BeforePackage registers a function to be run once before any tests in the given package are run. A package may only
-// have one BeforePackage function.
-//
-// If BeforePackage panics, no tests in the package will be run and the reporting behavior depends on if RunAsTest or
-// Run was called. AfterPackage will still be run.
-//
-// If RunAsTest was called, the panic will be reported as the top-level bootstrap test for the package. If Run was
-// called, every registered test in the package will be marked as failed with the panic's message.
-//
-// When run via Run, any logging output to the provided Tester will only be visible if BeforePackage panics or the
-// Tester is marked as failed. When run via RunAsTest, the standard `go test` output rules apply. Notably, if a test
-// fails, the output is not visible via Run but is via RunAsTest.
-//
-// NOTE: Do not call TestingT.Fail, TestingT.FailNow, TestingT.Fatal, or TestingT.Fatalf in BeforePackage to report
-// errors; always panic. It will work as expected in RunAsTest mode, but not Run mode. TODO parity here.
-//
-// The return value may be discarded (and is always nil); it is provided to simplify writing test code, like so:
-//
-//	var _ = testy.BeforePackage(func(){})
-func BeforePackage(f Tester) any {
-	pkg := getCallerPackage()
-	pkgTests := getPackageTests(pkg)
-
-	if pkgTests.BeforePackage != nil {
-		panic(fmt.Sprintf("package %s already has a BeforePackage", pkg))
-	}
-
-	pkgTests.BeforePackage = f
-	return nil
-}
-
-// AfterPackage registers a function to be run once after all tests in the given package have finished. A package may
-// only have one AfterPackage function.
-//
-// If AfterPackage panics, the reporting behavior depends on if RunAsTest or Run was called. If AfterPackage panics and
-// BeforePackage had already panicked, then the panic for BeforePackage takes priority.
-//
-// If RunAsTest was called, the panic will be reported as the top-level bootstrap test for the package. If Run was
-// called, every test in the package will be marked as failed, and the panic's message will be appended to every test's
-// own messages or the BeforePackage panic that replaced every test.
-//
-// When run via Run, any logging output to the provided Tester will only be visible if AfterPackage panics or the
-// Tester is marked as failed. When run via RunAsTest, the standard `go test` output rules apply. Notably, if a test
-// fails, the output is not visible via Run but is via RunAsTest.
-//
-// NOTE: Do not call TestingT.Fail, TestingT.FailNow, TestingT.Fatal, or TestingT.Fatalf in AfterPackage to report
-// errors; always panic. It will work as expected in RunAsTest mode, but not Run mode. TODO parity here.
-//
-// The return value may be discarded (and is always nil); it is provided to simplify writing test code, like so:
-//
-//	var _ = testy.AfterPackage(func(){})
-func AfterPackage(f Tester) any {
-	pkg := getCallerPackage()
-	pkgTests := getPackageTests(pkg)
-
-	if pkgTests.AfterPackage != nil {
-		panic(fmt.Sprintf("package %s already has an AfterPackage", pkg))
-	}
-
-	pkgTests.AfterPackage = f
-	return nil
-}
-
-// BeforeTest registers a function to be run before every top level registered test in the given package is run. It is
-// not run before subtests created by `t.Run`. A package may only have one BeforeTest function.
-//
-// If BeforeTest panics, the specific registered test that was about to be invoked will be marked as failed with the
-// panic's message. AfterTest will still be run.
-//
-// When run via Run, any logging output to the provided Tester will only be visible if BeforeTest panics or the
-// Tester is marked as failed. When run via RunAsTest, the standard `go test` output rules apply. Notably, if a test
-// fails, the output is not visible via Run but is via RunAsTest.
-//
-// NOTE: Do not call TestingT.Fail, TestingT.FailNow, TestingT.Fatal, or TestingT.Fatalf in BeforeTest to report
-// errors; always panic. It will work as expected in RunAsTest mode, but not Run mode. TODO parity here.
-//
-// The return value may be discarded (and is always nil); it is provided to simplify writing test code, like so:
-//
-//	var _ = testy.BeforeTest(func(){})
-func BeforeTest(f Tester) any {
-	pkg := getCallerPackage()
-	pkgTests := getPackageTests(pkg)
-
-	if pkgTests.BeforeTest != nil {
-		panic(fmt.Sprintf("package %s already has a BeforeTest", pkg))
-	}
-
-	pkgTests.BeforeTest = f
-	return nil
-}
-
-// AfterTest registers a function to be run once after every top level registered test in the given package has
-// finished. It is not run after subtests created by `t.Run`. A package may only have one AfterTest function.
-//
-// If AfterTest panics, the specific test that was just run will be marked as failed, and the panic's message will be
-// appended to the test's own messages. Any subtests of the test will not be modified.
-//
-// When run via Run, any logging output to the provided Tester will only be visible if AfterTest panics or the
-// Tester is marked as failed. When run via RunAsTest, the standard `go test` output rules apply. Notably, if a test
-// fails, the output is not visible via Run but is via RunAsTest.
-//
-// NOTE: Do not call TestingT.Fail, TestingT.FailNow, TestingT.Fatal, or TestingT.Fatalf in AfterTest to report
-// errors; always panic. It will work as expected in RunAsTest mode, but not Run mode. TODO parity here.
-//
-// The return value may be discarded (and is always nil); it is provided to simplify writing test code, like so:
-//
-//	var _ = testy.AfterTest(func(){})
-func AfterTest(f Tester) any {
-	pkg := getCallerPackage()
-	pkgTests := getPackageTests(pkg)
-
-	if pkgTests.AfterTest != nil {
-		panic(fmt.Sprintf("package %s already has an AfterTest", pkg))
-	}
-
-	pkgTests.AfterTest = f
-	return nil
 }

--- a/run.go
+++ b/run.go
@@ -246,7 +246,7 @@ func Run() TestResult {
 			anyFailures = true
 		}
 		pkgResults.Result = r
-		dur := time.Now().Sub(pkgStart).Round(time.Millisecond)
+		dur := time.Since(pkgStart).Round(time.Millisecond)
 		pkgResults.Dur = dur
 		pkgResults.DurHuman = dur.String()
 
@@ -258,7 +258,7 @@ func Run() TestResult {
 		r = ResultFailed
 	}
 	results.Result = r
-	dur := time.Now().Sub(start).Round(time.Millisecond)
+	dur := time.Since(start).Round(time.Millisecond)
 	results.Dur = dur
 	results.DurHuman = dur.String()
 	return results
@@ -311,7 +311,7 @@ func runTest(pkg, baseName string, tester Tester) TestResult {
 	// doesn't hurt to be careful
 	stWg.Wait()
 	close(subtestDone)
-	dur := time.Now().Sub(start).Round(time.Millisecond)
+	dur := time.Since(start).Round(time.Millisecond)
 
 	r := ResultPassed
 	if t.failed || anyFailures {

--- a/run.go
+++ b/run.go
@@ -8,14 +8,12 @@ import (
 	"time"
 )
 
-// RunAsTest runs all registered tests under Go's testing framework. To run tests on a per-package basis, put a test
-// file in each package containing a single test that calls this function. This is recommended so accurate per-package
-// execution times are reported, as well as using the test cache. Do not import a test package into another test package
-// as that will cause the tests in the second package to get executed with the first package. If code or resources need
-// shared between test packages, put them in their own package which does not contain any test definitions.
+// RunAsTest runs all registered tests under Go's testing framework.
 //
-// Individual tests in a package may still be run using the standard -run test flag. See `go help testflag` for more
-// information.
+// To run tests on a per-package basis, put a test file in each package containing a single test that calls this function.
+// This is recommended so accurate per-package execution times are reported, as well as using the test cache.
+// Do not import a test package into another test package as that will cause the tests in the second package to get executed with the first package.
+// If code or resources need shared between test packages, put them in their own package which does not contain any test definitions.
 //
 // TODO: shuffle test execution order (see -shuffle in `go help testflag`)
 func RunAsTest(t *testing.T) {
@@ -83,7 +81,9 @@ func RunAsTest(t *testing.T) {
 // Run runs all registered tests and returns result information about them.
 //
 // TODO: ability to filter for specific packages and tests
+//
 // TODO: shuffle test execution order (see -shuffle in `go help testflag`)
+//
 // TODO: channel for results to support progressive result loading?
 func Run() TestResult {
 	start := time.Now()


### PR DESCRIPTION
do not force docs to line wrap, as that can cause the diff to explode
when making minor changes. instead, break lines after sentences or other
punctuation if lines are unreasonably long. this is an unfortunately
large diff, but this commit should _only_ be these changes.

merge base is #17 